### PR TITLE
add should_poke configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,14 @@ Usage
 -----
 Add this configuration to your config file:
 
-	Dynopoker.configure do |config|
-  		config.address = 'http://wakemydyno.com'
-	#  config.enable = false # default is true
-	#  config.poke_frequency = 123 # default is 1800s (30min)
-	end
+```ruby
+Dynopoker.configure do |config|
+  config.address = 'http://wakemydyno.com'
+  #  config.enable = false # default is true
+  #  config.poke_frequency = 123 # default is 1800s (30min)
+  #  config.should_poke = Proc.new{ (8..19).include?(Time.now.hour) } # default is Proc.new { true } (always poke)
+end
+```
 
 TODO
 -----

--- a/lib/dynopoker.rb
+++ b/lib/dynopoker.rb
@@ -12,7 +12,7 @@ module Dynopoker
   end
 
   class Poker
-    attr_accessor :enable, :address, :poke_frequency, :logger
+    attr_accessor :enable, :address, :poke_frequency, :logger, :should_poke
     alias_method :enable?, :enable
 
     def start!
@@ -30,7 +30,7 @@ module Dynopoker
 
     def poking
       while true
-        poke!
+        poke! if should_poke.call
         sleep(poke_frequency)
       end
     end
@@ -46,6 +46,7 @@ module Dynopoker
       self.poke_frequency ||= 1800
       self.logger ||= Logger.new($stdout)
       self.enable = enable.nil? ? true : enable
+      self.should_poke = Proc.new { true }
       raise('Dynopoker: no address provided!') if (enable? && !valid_address?)
     end
 

--- a/spec/poker_spec.rb
+++ b/spec/poker_spec.rb
@@ -86,6 +86,21 @@ describe Dynopoker::Poker do
         subject.start!
       }.to raise_error(Exception, 'breaking while true loop')
     end
-  end
 
+    context 'should_poke configuration option set' do
+      it 'should poke regarding the result of the proc' do
+        stub_request(:get, 'http://test.org')
+        proc = Proc.new { true }
+
+        expect(proc).to receive(:call).twice.and_return(true, false)
+        subject.stub(:address => 'http://test.org', :should_poke => proc)
+
+        expect {
+          subject.start!
+        }.to raise_error(Exception, 'breaking while true loop')
+
+        WebMock.should have_requested(:get, 'http://test.org').once
+      end
+    end
+  end
 end


### PR DESCRIPTION
Hey there,

Don't know if you saw this => https://blog.heroku.com/archives/2015/5/7/new-dyno-types-public-beta
**TL;DR** : free dynos will be limited to 18h uptime a day, because most websites on free dynos don't need to be up all day round (like at 2 or 3am)

So here's a small PR to add an option to define if a ping should happen.
